### PR TITLE
Enhance CloudFront configuration with custom cache policy and read timeout

### DIFF
--- a/.opencode/commands/run-tests.md
+++ b/.opencode/commands/run-tests.md
@@ -7,18 +7,49 @@ compatibility: opencode
 
 # Run Tests Command
 
-This project uses Gradle for testing. Here are the available test commands:
+This project uses Gradle for testing.
+
+## Recommended Workflow
+
+Before running any tests, always perform these three steps in order to ensure a clean state:
+
+```bash
+# Step 1 — Clean build artifacts (removes stale class files and cached test results)
+./gradlew clean
+
+# Step 2 — Compile and build the project (catches compilation errors early)
+./gradlew build -x test
+
+# Step 3 — Run the tests
+./gradlew test        # standard test run
+# or
+./gradlew ciTest      # CI-style run with verbose failure output
+```
+
+All in one line:
+
+```bash
+./gradlew clean build -x test test
+```
+
+Or with CI-style verbose failures:
+
+```bash
+./gradlew clean build -x test ciTest
+```
+
+> **Note:** `clean` removes previous build outputs and cached test results, ensuring stale artifacts do not affect test outcomes. `build -x test` compiles main and test code *without* running tests yet, surfacing any compilation failures before the test execution phase.
 
 ## Run All Tests
 
 ```bash
-./gradlew test
+./gradlew clean build -x test test
 ```
 
 ## CI-Style Test Run (Verbose Failures)
 
 ```bash
-./gradlew ciTest
+./gradlew clean build -x test ciTest
 ```
 
 This runs tests with verbose output, showing detailed failure information. Use this before pushing code.
@@ -26,29 +57,29 @@ This runs tests with verbose output, showing detailed failure information. Use t
 ## Run a Single Test Class
 
 ```bash
-./gradlew test --tests 'cat.complai.SomeTest'
+./gradlew clean build -x test test --tests 'cat.complai.SomeTest'
 ```
 
 Example:
 ```bash
-./gradlew test --tests 'cat.complai.HomeControllerTest'
+./gradlew clean build -x test test --tests 'cat.complai.HomeControllerTest'
 ```
 
 ## Run a Single Test Method
 
 ```bash
-./gradlew test --tests 'cat.complai.SomeTest.testMethodName'
+./gradlew clean build -x test test --tests 'cat.complai.SomeTest.testMethodName'
 ```
 
 Example:
 ```bash
-./gradlew test --tests 'cat.complai.HomeControllerTest.testHome'
+./gradlew clean build -x test test --tests 'cat.complai.HomeControllerTest.testHome'
 ```
 
 ## Run Tests for a Nested Class
 
 ```bash
-./gradlew test --tests 'cat.complai.SomeTest$NestedClass'
+./gradlew clean build -x test test --tests 'cat.complai.SomeTest$NestedClass'
 ```
 
 ## Test Authentication

--- a/cdk/edge-stack.ts
+++ b/cdk/edge-stack.ts
@@ -66,7 +66,39 @@ export class EdgeStack extends cdk.Stack {
 
     const origin = new origins.HttpOrigin(
       `${httpApiId}.execute-api.${httpApiRegion}.amazonaws.com`,
+      {
+        // The read timeout must match the Lambda timeout (60 s) so that long-running
+        // requests like SSE streaming on /complai/ask are not terminated by CloudFront.
+        readTimeout: cdk.Duration.seconds(60),
+      },
     );
+
+    // Custom cache policy: cache idempotent responses (GET, HEAD, OPTIONS) for 60 s.
+    // POST / PUT / DELETE / PATCH requests are never cached by CloudFront regardless
+    // of the cache policy — they always reach the origin.
+    //
+    // This means:
+    //   - GET /, GET /health, GET /health/startup → cached for 60 s
+    //   - POST /complai/ask, POST /complai/redact, POST /complai/feedback → NOT cached
+    //   - OPTIONS preflight responses → cached for 60 s (keyed on Origin + CORS headers)
+    const cachePolicy = new cloudfront.CachePolicy(this, `ComplAICachePolicy-${environment}`, {
+      cachePolicyName: `ComplAICachePolicy-${environment}`,
+      comment: `Caches GET/HEAD/OPTIONS for 60 s — ComplAI ${environment}`,
+      defaultTtl: cdk.Duration.seconds(60),
+      minTtl: cdk.Duration.seconds(0),
+      maxTtl: cdk.Duration.seconds(60),
+      cookieBehavior: cloudfront.CacheCookieBehavior.none(),
+      // Include CORS-related headers in the cache key so that OPTIONS preflight
+      // responses are cached correctly for each distinct CORS request.
+      headerBehavior: cloudfront.CacheHeaderBehavior.allowList(
+        'Origin',
+        'Access-Control-Request-Method',
+        'Access-Control-Request-Headers',
+      ),
+      queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
+      enableAcceptEncodingGzip: true,
+      enableAcceptEncodingBrotli: true,
+    });
 
     const distribution = new cloudfront.Distribution(this, `ComplAIDistribution-${environment}`, {
       comment: `ComplAI CloudFront - ${environment}`,
@@ -74,7 +106,7 @@ export class EdgeStack extends cdk.Stack {
       defaultBehavior: {
         origin,
         allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
-        cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+        cachePolicy,
         originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
       },
     });


### PR DESCRIPTION
Introduce a custom cache policy for CloudFront to cache idempotent responses for 60 seconds and set a read timeout to match the Lambda timeout for SSE streaming. This improves performance and ensures long-running requests are not terminated prematurely.