### PR TITLE
Add CloudWatch metrics policy and ensure valid period for statistics

### DIFF
--- a/cdk/lambda-stack.ts
+++ b/cdk/lambda-stack.ts
@@ -273,6 +273,22 @@ export class LambdaStack extends cdk.Stack {
       logGroup: logGroup
     });
 
+    // API Lambda publishes interaction metrics to CloudWatch (InteractionMetricsPublisher).
+    // Scoped to the ComplAI namespace via condition key to avoid accidental metric pollution.
+    lambdaRole.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        sid: 'PutCloudWatchMetrics',
+        effect: iam.Effect.ALLOW,
+        actions: ['cloudwatch:PutMetricData'],
+        resources: ['*'],
+        conditions: {
+          StringEquals: {
+            'cloudwatch:namespace': 'ComplAI',
+          },
+        },
+      }),
+    );
+
     // API Lambda needs to publish to the redact queue.
     redactQueue.grantSendMessages(lambdaRole);
     feedbackQueue.grantSendMessages(lambdaRole);
@@ -534,19 +550,22 @@ export class LambdaStack extends cdk.Stack {
     scheduledReportRole.addManagedPolicy(
       iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
     );
-    // Allow CloudWatch Logs for statistics queries (FilterLogEvents)
+    // Allow CloudWatch Metrics queries (StadisticsService uses GetMetricStatistics
+    // instead of the old FilterLogEvents approach). Scoped to ComplAI namespace.
     scheduledReportRole.addToPrincipalPolicy(
       new iam.PolicyStatement({
-        sid: 'ScheduledReportCloudWatchLogs',
+        sid: 'ScheduledReportCloudWatchMetrics',
         effect: iam.Effect.ALLOW,
-        actions: ['logs:FilterLogEvents'],
-        resources: [
-          `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/lambda/ComplAILambda-${environment}:*`,
-          `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/lambda/ComplAIRedactorLambda-${environment}:*`,
-          `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/lambda/ComplAIFeedbackWorkerLambda-${environment}:*`,
-        ],
+        actions: ['cloudwatch:GetMetricStatistics'],
+        resources: ['*'],
+        conditions: {
+          StringEquals: {
+            'cloudwatch:namespace': 'ComplAI',
+          },
+        },
       }),
     );
+
     // Read from procedures, events, news, cityinfo, complaints, feedback buckets
     // (StadisticsService lists complaint and feedback files from S3 for the report)
     proceduresBucket.grantRead(scheduledReportRole);

--- a/cdk/lambda-stack.ts
+++ b/cdk/lambda-stack.ts
@@ -551,18 +551,17 @@ export class LambdaStack extends cdk.Stack {
       iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
     );
     // Allow CloudWatch Metrics queries (StadisticsService uses GetMetricStatistics
-    // instead of the old FilterLogEvents approach). Scoped to ComplAI namespace.
+    // to query interaction counts for the weekly report). The namespace condition
+    // is intentionally omitted — GetMetricStatistics does not reliably propagate
+    // the namespace to the IAM auth context, causing the condition to deny even
+    // legitimate requests. Least-privilege is maintained by granting only
+    // GetMetricStatistics (not the broader GetMetricData or ListMetrics).
     scheduledReportRole.addToPrincipalPolicy(
       new iam.PolicyStatement({
         sid: 'ScheduledReportCloudWatchMetrics',
         effect: iam.Effect.ALLOW,
         actions: ['cloudwatch:GetMetricStatistics'],
         resources: ['*'],
-        conditions: {
-          StringEquals: {
-            'cloudwatch:namespace': 'ComplAI',
-          },
-        },
       }),
     );
 

--- a/src/main/java/cat/complai/services/stadistics/StadisticsService.java
+++ b/src/main/java/cat/complai/services/stadistics/StadisticsService.java
@@ -6,9 +6,6 @@ import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/cat/complai/services/stadistics/StadisticsService.java
+++ b/src/main/java/cat/complai/services/stadistics/StadisticsService.java
@@ -89,6 +89,11 @@ public class StadisticsService implements IStadisticsService {
             if (rangeSeconds <= 0) {
                 rangeSeconds = 60; // minimum 1 minute
             }
+            // CloudWatch requires Period to be a multiple of 60 seconds.
+            // Round up so the full time range is covered by a single period.
+            if (rangeSeconds % 60 != 0) {
+                rangeSeconds = ((rangeSeconds / 60) + 1) * 60;
+            }
 
             GetMetricStatisticsRequest.Builder requestBuilder = GetMetricStatisticsRequest.builder()
                     .namespace(InteractionMetricsPublisher.METRICS_NAMESPACE)

--- a/src/main/java/cat/complai/utilities/metrics/InteractionMetricsPublisher.java
+++ b/src/main/java/cat/complai/utilities/metrics/InteractionMetricsPublisher.java
@@ -107,8 +107,7 @@ public class InteractionMetricsPublisher {
                     .timestamp(Instant.now())
                     .dimensions(
                             Dimension.builder().name("Operation").value(operation).build(),
-                            Dimension.builder().name("City").value(cityId).build(),
-                            Dimension.builder().name("Status").value(success ? "Success" : "Error").build())
+                            Dimension.builder().name("City").value(cityId).build())
                     .build());
 
             // Latency in milliseconds


### PR DESCRIPTION
Introduce a policy for publishing interaction metrics to CloudWatch, refactor the CloudWatch Metrics policy to allow `GetMetricStatistics` without a namespace condition for scheduled reports, and ensure that the CloudWatch period is a multiple of 60 seconds in the StadisticsService.