### PR TITLE
Refactor SES scheduled report handler to use a map

### DIFF
--- a/src/main/java/cat/complai/services/ses/SesScheduledReportHandler.java
+++ b/src/main/java/cat/complai/services/ses/SesScheduledReportHandler.java
@@ -1,8 +1,8 @@
 package cat.complai.services.ses;
 
+import java.util.Map;
 import java.util.logging.Logger;
 
-import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
 import io.micronaut.function.aws.MicronautRequestHandler;
 import jakarta.inject.Inject;
 
@@ -24,7 +24,7 @@ import jakarta.inject.Inject;
  * <p>Local development: the handler is invoked via {@code sam local invoke} by
  * {@code ses_scheduled_poller.py}, which runs on a cron-like loop through SAM.
  */
-public class SesScheduledReportHandler extends MicronautRequestHandler<ScheduledEvent, String> {
+public class SesScheduledReportHandler extends MicronautRequestHandler<Map<String, Object>, String> {
 
     private static final Logger logger = Logger.getLogger(SesScheduledReportHandler.class.getName());
 
@@ -32,10 +32,10 @@ public class SesScheduledReportHandler extends MicronautRequestHandler<Scheduled
     private MultiCitySesService multiCityService;
 
     @Override
-    public String execute(ScheduledEvent event) {
+    public String execute(Map<String, Object> event) {
         logger.info("SesScheduledReportHandler — scheduled invocation received");
-        logger.info(() -> "Event source: " + event.getSource()
-                + " | detail-type: " + event.getDetailType());
+        logger.info(() -> "Event source: " + event.get("source")
+                + " | detail-type: " + event.get("detail-type"));
         return multiCityService.runReportsForAllCities();
     }
 }

--- a/src/test/java/cat/complai/services/ses/SesScheduledReportHandlerTest.java
+++ b/src/test/java/cat/complai/services/ses/SesScheduledReportHandlerTest.java
@@ -1,11 +1,11 @@
 package cat.complai.services.ses;
 
-import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -25,7 +25,11 @@ class SesScheduledReportHandlerTest {
         field.setAccessible(true);
         field.set(handler, multiCityService);
 
-        ScheduledEvent event = new ScheduledEvent();
+        Map<String, Object> event = Map.of(
+            "source", "aws.events",
+            "detail-type", "Scheduled Event",
+            "time", "2026-05-18T03:00:00Z"
+        );
         String result = handler.execute(event);
 
         assertEquals("OK: all reports sent", result);
@@ -45,7 +49,11 @@ class SesScheduledReportHandlerTest {
         field.setAccessible(true);
         field.set(handler, multiCityService);
 
-        ScheduledEvent event = new ScheduledEvent();
+        Map<String, Object> event = Map.of(
+            "source", "aws.events",
+            "detail-type", "Scheduled Event",
+            "time", "2026-05-18T03:00:00Z"
+        );
         String result = handler.execute(event);
 
         assertEquals(expected, result);


### PR DESCRIPTION
Update the `SesScheduledReportHandler` to accept a `Map<String, Object>` instead of a `ScheduledEvent`. Adjust logging and tests accordingly to reflect this change. This improves flexibility in handling scheduled events.