### PR TITLE
Add PrivacyController and update filters for privacy policy endpoint

### DIFF
--- a/src/main/java/cat/complai/controllers/privacy/PrivacyController.java
+++ b/src/main/java/cat/complai/controllers/privacy/PrivacyController.java
@@ -1,0 +1,284 @@
+package cat.complai.controllers.privacy;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.QueryValue;
+
+/**
+ * Controller serving the privacy policy as a self-contained HTML page.
+ *
+ * <p>The endpoint is public (excluded from API key auth and rate limiting)
+ * and supports three languages via the {@code lang} query parameter:
+ * Catalan ({@code ca}, default), Spanish ({@code es}), and English ({@code en}).
+ *
+ * <p>The HTML page includes a language switcher that reloads the page with
+ * the selected language.
+ */
+@Controller("/privacy")
+public class PrivacyController {
+
+    /**
+     * Returns the privacy policy HTML page.
+     *
+     * @param lang the language code: "ca" (Catalan, default), "es" (Spanish), or "en" (English)
+     * @return 200 OK with text/html content
+     */
+    @Get
+    public HttpResponse<String> privacy(@QueryValue("lang") String lang) {
+        String language = sanitizeLang(lang);
+        String html = buildHtml(language);
+        return HttpResponse.ok(html).contentType(MediaType.TEXT_HTML);
+    }
+
+    private String sanitizeLang(String lang) {
+        if (lang == null || lang.isBlank()) {
+            return "ca";
+        }
+        String normalized = lang.trim().toLowerCase();
+        if (normalized.equals("es") || normalized.equals("en") || normalized.equals("ca")) {
+            return normalized;
+        }
+        return "ca";
+    }
+
+    private String buildHtml(String lang) {
+        String title;
+        String switcherCa;
+        String switcherEs;
+        String switcherEn;
+        String heading;
+        String lastUpdated;
+        String introTitle;
+        String introText;
+        String dataCollectionTitle;
+        String dataCollectionText;
+        String dataUsageTitle;
+        String dataUsageText;
+        String dataStorageTitle;
+        String dataStorageText;
+        String thirdPartyTitle;
+        String thirdPartyText;
+        String rightsTitle;
+        String rightsText;
+        String contactTitle;
+        String contactText;
+
+        if ("en".equals(lang)) {
+            title = "Privacy Policy — ComplAI";
+            switcherCa = "Català";
+            switcherEs = "Español";
+            switcherEn = "English";
+            heading = "Privacy Policy";
+            lastUpdated = "Last updated: July 2026";
+            introTitle = "1. Introduction";
+            introText = "ComplAI is a mobile application that helps citizens interact with municipal services using artificial intelligence. This privacy policy explains how we collect, use, and protect your personal data when you use our application.";
+            dataCollectionTitle = "2. Data We Collect";
+            dataCollectionText = "We collect the following types of data when you use ComplAI:\n• Personal identification: Name, surname, and ID number (provided when generating complaint letters).\n• User feedback: Username, user ID, message content, ratings, and category selections.\n• Chat conversations: Messages exchanged with the AI assistant during your sessions.\n• App preferences: Language selection and city selection (stored locally on your device).";
+            dataUsageTitle = "3. How We Use Your Data";
+            dataUsageText = "Your data is used for the following purposes:\n• To generate personalized complaint letters with your identification details.\n• To process and respond to your feedback submissions.\n• To maintain conversation context during AI chat sessions.\n• To remember your language and city preferences for a better experience.\n• To improve the quality of our AI services through aggregated, anonymized usage patterns.";
+            dataStorageTitle = "4. Data Storage and Security";
+            dataStorageText = "• Chat history and sensitive data are stored locally on your device using encrypted storage (Keychain on iOS, EncryptedSharedPreferences on Android).\n• Your language preference is stored locally using standard device storage.\n• Data sent to our servers is processed temporarily for generating responses and is not retained beyond the processing period.\n• We do not sell, share, or rent your personal data to third parties.";
+            thirdPartyTitle = "5. Third-Party Services";
+            thirdPartyText = "ComplAI uses the following third-party services:\n• Amazon Web Services (AWS): For hosting our API backend and processing requests.\n• OpenRouter: For AI-powered language processing and response generation.\n• Expo: For mobile application distribution and updates.\nEach of these services has its own privacy policy governing how they handle data.";
+            rightsTitle = "6. Your Rights";
+            rightsText = "You have the following rights regarding your personal data:\n• Access: You can view the data stored on your device within the app.\n• Deletion: You can clear all conversations and app data from the Settings screen.\n• Portability: Your chat history is stored locally and can be accessed through the app.\n• Withdrawal of consent: You can stop using the app at any time, and your local data will remain on your device until you delete it.";
+            contactTitle = "7. Contact";
+            contactText = "If you have questions about this privacy policy or your personal data, please contact us at:\nEmail: privacy@complai.cat";
+        } else if ("es".equals(lang)) {
+            title = "Política de Privacidad — ComplAI";
+            switcherCa = "Català";
+            switcherEs = "Español";
+            switcherEn = "English";
+            heading = "Política de Privacidad";
+            lastUpdated = "Última actualización: julio de 2026";
+            introTitle = "1. Introducción";
+            introText = "ComplAI es una aplicación móvil que ayuda a los ciudadanos a interactuar con los servicios municipales mediante inteligencia artificial. Esta política de privacidad explica cómo recopilamos, usamos y protegemos sus datos personales cuando utiliza nuestra aplicación.";
+            dataCollectionTitle = "2. Datos que Recopilamos";
+            dataCollectionText = "Recopilamos los siguientes tipos de datos cuando utiliza ComplAI:\n• Identificación personal: Nombre, apellidos y número de documento de identidad (proporcionados al generar cartas de reclamación).\n• Comentarios del usuario: Nombre de usuario, ID de usuario, contenido del mensaje, puntuaciones y selecciones de categoría.\n• Conversaciones de chat: Mensajes intercambiados con el asistente de IA durante sus sesiones.\n• Preferencias de la aplicación: Selección de idioma y selección de ciudad (almacenadas localmente en su dispositivo).";
+            dataUsageTitle = "3. Cómo Usamos Sus Datos";
+            dataUsageText = "Sus datos se utilizan para los siguientes fines:\n• Para generar cartas de reclamación personalizadas con sus datos de identificación.\n• Para procesar y responder a sus envíos de comentarios.\n• Para mantener el contexto de conversación durante las sesiones de chat con IA.\n• Para recordar sus preferencias de idioma y ciudad para una mejor experiencia.\n• Para mejorar la calidad de nuestros servicios de IA mediante patrones de uso agregados y anonimizados.";
+            dataStorageTitle = "4. Almacenamiento y Seguridad de Datos";
+            dataStorageText = "• El historial de chat y los datos sensibles se almacenan localmente en su dispositivo utilizando almacenamiento cifrado (Keychain en iOS, EncryptedSharedPreferences en Android).\n• Su preferencia de idioma se almacena localmente utilizando almacenamiento estándar del dispositivo.\n• Los datos enviados a nuestros servidores se procesan temporalmente para generar respuestas y no se conservan más allá del período de procesamiento.\n• No vendemos, compartimos ni alquilamos sus datos personales a terceros.";
+            thirdPartyTitle = "5. Servicios de Terceros";
+            thirdPartyText = "ComplAI utiliza los siguientes servicios de terceros:\n• Amazon Web Services (AWS): Para alojar nuestro backend de API y procesar solicitudes.\n• OpenRouter: Para el procesamiento de lenguaje y generación de respuestas con IA.\n• Expo: Para la distribución y actualizaciones de la aplicación móvil.\nCada uno de estos servicios tiene su propia política de privacidad que rige cómo maneja los datos.";
+            rightsTitle = "6. Sus Derechos";
+            rightsText = "Tiene los siguientes derechos con respecto a sus datos personales:\n• Acceso: Puede ver los datos almacenados en su dispositivo dentro de la aplicación.\n• Eliminación: Puede borrar todas las conversaciones y datos de la aplicación desde la pantalla de Configuración.\n• Portabilidad: Su historial de chat se almacena localmente y se puede acceder a través de la aplicación.\n• Retirada de consentimiento: Puede dejar de usar la aplicación en cualquier momento, y sus datos locales permanecerán en su dispositivo hasta que los elimine.";
+            contactTitle = "7. Contacto";
+            contactText = "Si tiene preguntas sobre esta política de privacidad o sus datos personales, por favor contáctenos en:\nCorreo electrónico: privacy@complai.cat";
+        } else {
+            title = "Política de Privacitat — ComplAI";
+            switcherCa = "Català";
+            switcherEs = "Español";
+            switcherEn = "English";
+            heading = "Política de Privacitat";
+            lastUpdated = "Última actualització: juliol de 2026";
+            introTitle = "1. Introducció";
+            introText = "ComplAI és una aplicació mòbil que ajuda els ciutadans a interactuar amb els serveis municipals mitjançant intel·ligència artificial. Aquesta política de privacitat explica com recollim, utilitzem i protegim les vostres dades personals quan utilitzeu la nostra aplicació.";
+            dataCollectionTitle = "2. Dades que Recollim";
+            dataCollectionText = "Recollim els següents tipus de dades quan utilitzeu ComplAI:\n• Identificació personal: Nom, cognoms i número de document d'identitat (proporcionats en generar cartes de reclamació).\n• Comentaris de l'usuari: Nom d'usuari, ID d'usuari, contingut del missatge, puntuacions i seleccions de categoria.\n• Converses de xat: Missatges intercanviats amb l'assistent d'IA durant les vostres sessions.\n• Preferències de l'aplicació: Selecció d'idioma i selecció de ciutat (emmagatzemades localment al vostre dispositiu).";
+            dataUsageTitle = "3. Com Utilitzem Les Vostres Dades";
+            dataUsageText = "Les vostres dades s'utilitzen per als següents fins:\n• Per generar cartes de reclamació personalitzades amb les vostres dades d'identificació.\n• Per processar i respondre als vostres enviaments de comentaris.\n• Per mantenir el context de conversa durant les sessions de xat amb IA.\n• Per recordar les vostres preferències d'idioma i ciutat per a una millor experiència.\n• Per millorar la qualitat dels nostres serveis d'IA mitjançant patrons d'ús agregats i anonimitzats.";
+            dataStorageTitle = "4. Emmagatzematge i Seguretat de Dades";
+            dataStorageText = "• L'historial de xat i les dades sensibles s'emmagatzemen localment al vostre dispositiu utilitzant emmagatzematge xifrat (Keychain a iOS, EncryptedSharedPreferences a Android).\n• La vostra preferència d'idioma s'emmagatzema localment utilitzant emmagatzematge estàndard del dispositiu.\n• Les dades enviades als nostres servidors es processen temporalment per generar respostes i no es conserven més enllà del període de processament.\n• No venem, compartim ni lloguem les vostres dades personals a tercers.";
+            thirdPartyTitle = "5. Serveis de Tercers";
+            thirdPartyText = "ComplAI utilitza els següents serveis de tercers:\n• Amazon Web Services (AWS): Per allotjar el nostre backend d'API i processar sol·licituds.\n• OpenRouter: Per al processament de llenguatge i generació de respostes amb IA.\n• Expo: Per a la distribució i actualitzacions de l'aplicació mòbil.\nCadascun d'aquests serveis té la seva pròpia política de privacitat que regeix com gestiona les dades.";
+            rightsTitle = "6. Els Vostres Drets";
+            rightsText = "Teniu els següents drets pel que fa a les vostres dades personals:\n• Accés: Podeu veure les dades emmagatzemades al vostre dispositiu dins de l'aplicació.\n• Eliminació: Podeu esborrar totes les converses i dades de l'aplicació des de la pantalla de Configuració.\n• Portabilitat: El vostre historial de xat s'emmagatzema localment i shi pot accedir a través de l'aplicació.\n• Retirada de consentiment: Podeu deixar dutilitzar laplicació en qualsevol moment, i les vostres dades locals romandran al vostre dispositiu fins que les elimineu.";
+            contactTitle = "7. Contacte";
+            contactText = "Si teniu preguntes sobre aquesta política de privacitat o les vostres dades personals, poseu-vos en contacte amb nosaltres a:\nCorreu electrònic: privacy@complai.cat";
+        }
+
+        // Build active language indicator
+        String activeCa = "ca".equals(lang) ? "font-weight:700;text-decoration:underline;" : "opacity:0.6;";
+        String activeEs = "es".equals(lang) ? "font-weight:700;text-decoration:underline;" : "opacity:0.6;";
+        String activeEn = "en".equals(lang) ? "font-weight:700;text-decoration:underline;" : "opacity:0.6;";
+
+        return """
+                <!DOCTYPE html>
+                <html lang="%s">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <title>%s</title>
+                    <style>
+                        * { margin: 0; padding: 0; box-sizing: border-box; }
+                        body {
+                            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+                            line-height: 1.6;
+                            color: #1a1a2e;
+                            background: #f8f9fa;
+                            padding: 20px;
+                            max-width: 800px;
+                            margin: 0 auto;
+                        }
+                        .header {
+                            text-align: center;
+                            padding: 30px 0 20px;
+                            border-bottom: 2px solid #e0e0e0;
+                            margin-bottom: 30px;
+                        }
+                        .header h1 {
+                            font-size: 28px;
+                            color: #1a1a2e;
+                            margin-bottom: 8px;
+                        }
+                        .header .date {
+                            font-size: 14px;
+                            color: #666;
+                        }
+                        .lang-switcher {
+                            display: flex;
+                            justify-content: center;
+                            gap: 16px;
+                            margin: 16px 0;
+                        }
+                        .lang-switcher a {
+                            color: #4361ee;
+                            text-decoration: none;
+                            font-size: 14px;
+                            padding: 6px 12px;
+                            border-radius: 6px;
+                            transition: background 0.2s;
+                        }
+                        .lang-switcher a:hover {
+                            background: rgba(67, 97, 238, 0.1);
+                        }
+                        .lang-switcher a.active {
+                            background: #4361ee;
+                            color: white;
+                        }
+                        .section {
+                            margin-bottom: 28px;
+                        }
+                        .section h2 {
+                            font-size: 20px;
+                            color: #1a1a2e;
+                            margin-bottom: 12px;
+                            padding-bottom: 8px;
+                            border-bottom: 1px solid #e0e0e0;
+                        }
+                        .section p {
+                            font-size: 15px;
+                            color: #333;
+                            white-space: pre-line;
+                        }
+                        .footer {
+                            text-align: center;
+                            padding-top: 30px;
+                            border-top: 2px solid #e0e0e0;
+                            margin-top: 30px;
+                            font-size: 13px;
+                            color: #888;
+                        }
+                    </style>
+                </head>
+                <body>
+                    <div class="header">
+                        <h1>%s</h1>
+                        <div class="date">%s</div>
+                        <div class="lang-switcher">
+                            <a href="?lang=ca" style="%s">%s</a>
+                            <a href="?lang=es" style="%s">%s</a>
+                            <a href="?lang=en" style="%s">%s</a>
+                        </div>
+                    </div>
+
+                    <div class="section">
+                        <h2>%s</h2>
+                        <p>%s</p>
+                    </div>
+
+                    <div class="section">
+                        <h2>%s</h2>
+                        <p>%s</p>
+                    </div>
+
+                    <div class="section">
+                        <h2>%s</h2>
+                        <p>%s</p>
+                    </div>
+
+                    <div class="section">
+                        <h2>%s</h2>
+                        <p>%s</p>
+                    </div>
+
+                    <div class="section">
+                        <h2>%s</h2>
+                        <p>%s</p>
+                    </div>
+
+                    <div class="section">
+                        <h2>%s</h2>
+                        <p>%s</p>
+                    </div>
+
+                    <div class="section">
+                        <h2>%s</h2>
+                        <p>%s</p>
+                    </div>
+
+                    <div class="footer">
+                        <p>ComplAI &copy; 2026</p>
+                    </div>
+                </body>
+                </html>
+                """.formatted(
+                lang,
+                title,
+                heading,
+                lastUpdated,
+                activeCa, switcherCa,
+                activeEs, switcherEs,
+                activeEn, switcherEn,
+                introTitle, introText,
+                dataCollectionTitle, dataCollectionText,
+                dataUsageTitle, dataUsageText,
+                dataStorageTitle, dataStorageText,
+                thirdPartyTitle, thirdPartyText,
+                rightsTitle, rightsText,
+                contactTitle, contactText);
+    }
+}

--- a/src/main/java/cat/complai/utilities/auth/ApiKeyAuthFilter.java
+++ b/src/main/java/cat/complai/utilities/auth/ApiKeyAuthFilter.java
@@ -28,7 +28,8 @@ import java.util.logging.Logger;
  * map, and sets the {@code "city"} and {@code "user"} request attributes for
  * downstream controllers.
  *
- * Excluded paths (no key required): GET /, GET /health, GET /health/startup, /telegram/**.
+ * Excluded paths (no key required): GET /, GET /health, GET /health/startup,
+ * GET /privacy, /telegram/**.
  *
  * Returning null from a {@code @RequestFilter} method tells Micronaut to
  * continue
@@ -113,7 +114,8 @@ public class ApiKeyAuthFilter {
         }
 
         return HttpMethod.GET.equals(method)
-                && (path.equals("/") || path.equals("/health") || path.equals("/health/startup"));
+                && (path.equals("/") || path.equals("/health") || path.equals("/health/startup")
+                        || path.equals("/privacy"));
     }
 
     private MutableHttpResponse<?> unauthorizedResponse(String reason) {

--- a/src/main/java/cat/complai/utilities/auth/RateLimitFilter.java
+++ b/src/main/java/cat/complai/utilities/auth/RateLimitFilter.java
@@ -36,7 +36,7 @@ import java.util.logging.Logger;
  *
  * <p>
  * Excluded paths (same as JwtAuthFilter): GET /, GET /health,
- * GET /health/startup — pass through immediately without incrementing.
+ * GET /health/startup, GET /privacy — pass through immediately without incrementing.
  */
 @Requires(property = "api.key.enabled")
 @ServerFilter("/**")
@@ -89,6 +89,7 @@ public class RateLimitFilter implements Ordered {
         String path = request.getPath();
         HttpMethod method = request.getMethod();
         return HttpMethod.GET.equals(method)
-                && (path.equals("/") || path.equals("/health") || path.equals("/health/startup"));
+                && (path.equals("/") || path.equals("/health") || path.equals("/health/startup")
+                        || path.equals("/privacy"));
     }
 }

--- a/src/test/java/cat/complai/controllers/privacy/PrivacyControllerTest.java
+++ b/src/test/java/cat/complai/controllers/privacy/PrivacyControllerTest.java
@@ -1,0 +1,250 @@
+package cat.complai.controllers.privacy;
+
+import io.micronaut.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link PrivacyController}.
+ *
+ * <p>Follows the project pattern for controller tests:
+ * <ul>
+ *   <li>No {@code @MicronautTest} — controller is instantiated directly (no dependencies)</li>
+ *   <li>HTTP request objects are built manually with
+ *       {@link HttpRequest#GET(String)}</li>
+ * </ul>
+ */
+public class PrivacyControllerTest {
+
+    private final PrivacyController controller = new PrivacyController();
+
+    // -------------------------------------------------------------------------
+    // Language parameter handling
+    // -------------------------------------------------------------------------
+
+    @Test
+    void privacy_nullLang_returnsCatalan() {
+        HttpResponse<String> response = controller.privacy(null);
+
+        assertEquals(200, response.getStatus().getCode());
+        String body = response.getBody().orElse("");
+        assertTrue(body.contains("Política de Privacitat"), "Should default to Catalan");
+        assertTrue(body.contains("lang=ca"), "Language switcher should link to ca");
+        assertTrue(body.contains("lang=es"), "Language switcher should link to es");
+        assertTrue(body.contains("lang=en"), "Language switcher should link to en");
+    }
+
+    @Test
+    void privacy_emptyLang_returnsCatalan() {
+        HttpResponse<String> response = controller.privacy("");
+
+        assertEquals(200, response.getStatus().getCode());
+        String body = response.getBody().orElse("");
+        assertTrue(body.contains("Política de Privacitat"), "Should default to Catalan");
+    }
+
+    @Test
+    void privacy_blankLang_returnsCatalan() {
+        HttpResponse<String> response = controller.privacy("   ");
+
+        assertEquals(200, response.getStatus().getCode());
+        String body = response.getBody().orElse("");
+        assertTrue(body.contains("Política de Privacitat"), "Should default to Catalan");
+    }
+
+    @Test
+    void privacy_ca_returnsCatalan() {
+        HttpResponse<String> response = controller.privacy("ca");
+
+        assertEquals(200, response.getStatus().getCode());
+        String body = response.getBody().orElse("");
+        assertTrue(body.contains("Política de Privacitat"), "Should return Catalan");
+        assertTrue(body.contains("Última actualització"), "Should contain Catalan date text");
+    }
+
+    @Test
+    void privacy_CA_uppercase_returnsCatalan() {
+        HttpResponse<String> response = controller.privacy("CA");
+
+        assertEquals(200, response.getStatus().getCode());
+        String body = response.getBody().orElse("");
+        assertTrue(body.contains("Política de Privacitat"), "Should return Catalan for uppercase CA");
+    }
+
+    @Test
+    void privacy_es_returnsSpanish() {
+        HttpResponse<String> response = controller.privacy("es");
+
+        assertEquals(200, response.getStatus().getCode());
+        String body = response.getBody().orElse("");
+        assertTrue(body.contains("Política de Privacidad"), "Should return Spanish");
+        assertTrue(body.contains("Última actualización"), "Should contain Spanish date text");
+    }
+
+    @Test
+    void privacy_ES_uppercase_returnsSpanish() {
+        HttpResponse<String> response = controller.privacy("ES");
+
+        assertEquals(200, response.getStatus().getCode());
+        String body = response.getBody().orElse("");
+        assertTrue(body.contains("Política de Privacidad"), "Should return Spanish for uppercase ES");
+    }
+
+    @Test
+    void privacy_en_returnsEnglish() {
+        HttpResponse<String> response = controller.privacy("en");
+
+        assertEquals(200, response.getStatus().getCode());
+        String body = response.getBody().orElse("");
+        assertTrue(body.contains("Privacy Policy"), "Should return English");
+        assertTrue(body.contains("Last updated:"), "Should contain English date text");
+    }
+
+    @Test
+    void privacy_EN_uppercase_returnsEnglish() {
+        HttpResponse<String> response = controller.privacy("EN");
+
+        assertEquals(200, response.getStatus().getCode());
+        String body = response.getBody().orElse("");
+        assertTrue(body.contains("Privacy Policy"), "Should return English for uppercase EN");
+    }
+
+    @Test
+    void privacy_invalidLang_french_fallbackToCatalan() {
+        HttpResponse<String> response = controller.privacy("fr");
+
+        assertEquals(200, response.getStatus().getCode());
+        String body = response.getBody().orElse("");
+        assertTrue(body.contains("Política de Privacitat"),
+                "Invalid language 'fr' should fallback to Catalan");
+    }
+
+    @Test
+    void privacy_invalidLang_german_fallbackToCatalan() {
+        HttpResponse<String> response = controller.privacy("de");
+
+        assertEquals(200, response.getStatus().getCode());
+        String body = response.getBody().orElse("");
+        assertTrue(body.contains("Política de Privacitat"),
+                "Invalid language 'de' should fallback to Catalan");
+    }
+
+    @Test
+    void privacy_invalidLang_numeric_fallbackToCatalan() {
+        HttpResponse<String> response = controller.privacy("123");
+
+        assertEquals(200, response.getStatus().getCode());
+        String body = response.getBody().orElse("");
+        assertTrue(body.contains("Política de Privacitat"),
+                "Numeric language '123' should fallback to Catalan");
+    }
+
+    // -------------------------------------------------------------------------
+    // Response format
+    // -------------------------------------------------------------------------
+
+    @Test
+    void privacy_returnsHtmlContentType() {
+        HttpResponse<String> response = controller.privacy("en");
+
+        assertEquals(200, response.getStatus().getCode());
+        assertTrue(response.getContentType().isPresent());
+        assertEquals("text/html", response.getContentType().get().toString());
+    }
+
+    @Test
+    void privacy_returnsValidHtmlStructure() {
+        HttpResponse<String> response = controller.privacy("en");
+        String body = response.getBody().orElse("");
+
+        assertTrue(body.contains("<!DOCTYPE html>"), "Should contain DOCTYPE declaration");
+        assertTrue(body.contains("<html"), "Should contain html tag");
+        assertTrue(body.contains("<head>"), "Should contain head tag");
+        assertTrue(body.contains("<body>"), "Should contain body tag");
+        assertTrue(body.contains("</html>"), "Should close html tag");
+    }
+
+    // -------------------------------------------------------------------------
+    // Privacy policy content
+    // -------------------------------------------------------------------------
+
+    @Test
+    void privacy_englishContainsAllSections() {
+        HttpResponse<String> response = controller.privacy("en");
+        String body = response.getBody().orElse("");
+
+        assertTrue(body.contains("1. Introduction"), "Should contain Introduction section");
+        assertTrue(body.contains("2. Data We Collect"), "Should contain Data Collection section");
+        assertTrue(body.contains("3. How We Use Your Data"), "Should contain Data Usage section");
+        assertTrue(body.contains("4. Data Storage and Security"), "Should contain Storage section");
+        assertTrue(body.contains("5. Third-Party Services"), "Should contain Third-Party section");
+        assertTrue(body.contains("6. Your Rights"), "Should contain Rights section");
+        assertTrue(body.contains("7. Contact"), "Should contain Contact section");
+        assertTrue(body.contains("privacy@complai.cat"), "Should contain contact email");
+    }
+
+    @Test
+    void privacy_catalanContainsAllSections() {
+        HttpResponse<String> response = controller.privacy("ca");
+        String body = response.getBody().orElse("");
+
+        assertTrue(body.contains("1. Introducció"), "Should contain Catalan Introduction");
+        assertTrue(body.contains("2. Dades que Recollim"), "Should contain Catalan Data Collection");
+        assertTrue(body.contains("3. Com Utilitzem Les Vostres Dades"), "Should contain Catalan Data Usage");
+        assertTrue(body.contains("4. Emmagatzematge i Seguretat de Dades"), "Should contain Catalan Storage");
+        assertTrue(body.contains("5. Serveis de Tercers"), "Should contain Catalan Third-Party");
+        assertTrue(body.contains("6. Els Vostres Drets"), "Should contain Catalan Rights");
+        assertTrue(body.contains("7. Contacte"), "Should contain Catalan Contact");
+        assertTrue(body.contains("privacy@complai.cat"), "Should contain contact email");
+    }
+
+    @Test
+    void privacy_spanishContainsAllSections() {
+        HttpResponse<String> response = controller.privacy("es");
+        String body = response.getBody().orElse("");
+
+        assertTrue(body.contains("1. Introducción"), "Should contain Spanish Introduction");
+        assertTrue(body.contains("2. Datos que Recopilamos"), "Should contain Spanish Data Collection");
+        assertTrue(body.contains("3. Cómo Usamos Sus Datos"), "Should contain Spanish Data Usage");
+        assertTrue(body.contains("4. Almacenamiento y Seguridad de Datos"), "Should contain Spanish Storage");
+        assertTrue(body.contains("5. Servicios de Terceros"), "Should contain Spanish Third-Party");
+        assertTrue(body.contains("6. Sus Derechos"), "Should contain Spanish Rights");
+        assertTrue(body.contains("7. Contacto"), "Should contain Spanish Contact");
+        assertTrue(body.contains("privacy@complai.cat"), "Should contain contact email");
+    }
+
+    @Test
+    void privacy_containsLanguageSwitcher() {
+        HttpResponse<String> response = controller.privacy("ca");
+        String body = response.getBody().orElse("");
+
+        assertTrue(body.contains("href=\"?lang=ca\""), "Switcher should have Catalan link");
+        assertTrue(body.contains("href=\"?lang=es\""), "Switcher should have Spanish link");
+        assertTrue(body.contains("href=\"?lang=en\""), "Switcher should have English link");
+        assertTrue(body.contains("Català"), "Switcher should show Catalan label");
+        assertTrue(body.contains("Español"), "Switcher should show Spanish label");
+        assertTrue(body.contains("English"), "Switcher should show English label");
+    }
+
+    @Test
+    void privacy_activeLanguageHighlighted() {
+        // When lang=en, the English link should have the active style
+        HttpResponse<String> response = controller.privacy("en");
+        String body = response.getBody().orElse("");
+
+        // The active language link should NOT have opacity:0.6
+        // The inactive ones should have opacity:0.6
+        assertTrue(body.contains("opacity:0.6;"), "Inactive languages should have opacity style");
+        assertTrue(body.contains("font-weight:700"), "Active language should have bold style");
+    }
+
+    @Test
+    void privacy_containsComplAiCopyright() {
+        HttpResponse<String> response = controller.privacy("en");
+        String body = response.getBody().orElse("");
+
+        assertTrue(body.contains("ComplAI"), "Should contain app name");
+        assertTrue(body.contains("2026"), "Should contain copyright year");
+    }
+}

--- a/src/test/java/cat/complai/controllers/privacy/PrivacyEndpointAuthTest.java
+++ b/src/test/java/cat/complai/controllers/privacy/PrivacyEndpointAuthTest.java
@@ -1,0 +1,87 @@
+package cat.complai.controllers.privacy;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * HTTP integration test verifying that the privacy policy endpoint is excluded
+ * from API key authentication.
+ *
+ * <p>{@code GET /privacy} must return HTTP 200 with text/html content <em>without</em>
+ * an {@code X-Api-Key} header. This test runs through the full Micronaut filter chain
+ * (including {@link cat.complai.utilities.auth.TestApiKeyFilter}) to confirm the
+ * exclusion works end-to-end.
+ *
+ * <p>Regression guard: previously {@code TestApiKeyFilter} was missing the
+ * {@code /privacy} exclusion, so tests could not catch production failures where
+ * the endpoint returned 401 "Missing X-Api-Key header".
+ */
+@MicronautTest
+class PrivacyEndpointAuthTest {
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    @Test
+    void getPrivacy_withoutApiKey_returns200() {
+        HttpResponse<String> response = client.toBlocking()
+                .exchange(HttpRequest.GET("/privacy?lang=ca"), String.class);
+
+        assertEquals(200, response.getStatus().getCode());
+    }
+
+    @Test
+    void getPrivacy_withoutApiKey_returnsHtml() {
+        HttpResponse<String> response = client.toBlocking()
+                .exchange(HttpRequest.GET("/privacy?lang=en"), String.class);
+
+        assertEquals(200, response.getStatus().getCode());
+        assertTrue(response.getContentType().isPresent());
+        assertEquals(MediaType.TEXT_HTML_TYPE, response.getContentType().get());
+    }
+
+    @Test
+    void getPrivacy_withoutApiKey_containsCatalanContent() {
+        HttpResponse<String> response = client.toBlocking()
+                .exchange(HttpRequest.GET("/privacy?lang=ca"), String.class);
+
+        assertEquals(200, response.getStatus().getCode());
+        String body = response.body();
+        assertNotNull(body);
+        assertTrue(body.contains("Política de Privacitat"),
+                "Response should contain Catalan privacy policy heading");
+    }
+
+    @Test
+    void getPrivacy_withoutApiKey_containsEnglishContent() {
+        HttpResponse<String> response = client.toBlocking()
+                .exchange(HttpRequest.GET("/privacy?lang=en"), String.class);
+
+        assertEquals(200, response.getStatus().getCode());
+        String body = response.body();
+        assertNotNull(body);
+        assertTrue(body.contains("Privacy Policy"),
+                "Response should contain English privacy policy heading");
+    }
+
+    @Test
+    void getPrivacy_withoutApiKey_containsSpanishContent() {
+        HttpResponse<String> response = client.toBlocking()
+                .exchange(HttpRequest.GET("/privacy?lang=es"), String.class);
+
+        assertEquals(200, response.getStatus().getCode());
+        String body = response.body();
+        assertNotNull(body);
+        assertTrue(body.contains("Política de Privacidad"),
+                "Response should contain Spanish privacy policy heading");
+    }
+}

--- a/src/test/java/cat/complai/utilities/auth/TestApiKeyFilter.java
+++ b/src/test/java/cat/complai/utilities/auth/TestApiKeyFilter.java
@@ -55,8 +55,13 @@ public class TestApiKeyFilter {
     private static boolean isExcluded(HttpRequest<?> request) {
         String path = request.getPath();
         HttpMethod method = request.getMethod();
+        // Exclude Telegram webhook paths from auth (Telegram cannot send X-Api-Key)
+        if (path != null && path.startsWith("/telegram/")) {
+            return true;
+        }
         return HttpMethod.GET.equals(method)
-                && (path.equals("/") || path.equals("/health") || path.equals("/health/startup"));
+                && (path.equals("/") || path.equals("/health") || path.equals("/health/startup")
+                        || path.equals("/privacy"));
     }
 
     private MutableHttpResponse<?> unauthorizedResponse(String reason) {

--- a/src/test/java/cat/complai/utilities/http/CorsFilterTest.java
+++ b/src/test/java/cat/complai/utilities/http/CorsFilterTest.java
@@ -3,6 +3,7 @@ package cat.complai.utilities.http;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.MutableHttpHeaders;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -12,10 +13,21 @@ class CorsFilterTest {
 
     private static final String TEST_ORIGIN = "http://localhost:3000";
 
+    /**
+     * Creates a mock request with the given method and an empty (but non-null)
+     * {@link HttpHeaders} so that {@code request.getHeaders().get("Origin")}
+     * returns {@code null} instead of throwing {@link NullPointerException}.
+     */
+    private static MutableHttpRequest<?> mockRequest(HttpMethod method) {
+        MutableHttpRequest<?> request = mock(MutableHttpRequest.class);
+        when(request.getMethod()).thenReturn(method);
+        when(request.getHeaders()).thenReturn(mock(MutableHttpHeaders.class));
+        return request;
+    }
+
     @Test
     void handlePreflight_returnsResponseWithCorsHeadersForOptionsRequest() {
-        MutableHttpRequest<?> request = mock(MutableHttpRequest.class);
-        when(request.getMethod()).thenReturn(HttpMethod.OPTIONS);
+        MutableHttpRequest<?> request = mockRequest(HttpMethod.OPTIONS);
 
         CorsFilter filter = new CorsFilter(TEST_ORIGIN);
 
@@ -34,8 +46,7 @@ class CorsFilterTest {
 
     @Test
     void handlePreflight_returnsNullForNonOptionsRequest() {
-        MutableHttpRequest<?> request = mock(MutableHttpRequest.class);
-        when(request.getMethod()).thenReturn(HttpMethod.GET);
+        MutableHttpRequest<?> request = mockRequest(HttpMethod.GET);
 
         CorsFilter filter = new CorsFilter(TEST_ORIGIN);
 
@@ -45,8 +56,7 @@ class CorsFilterTest {
     @Test
     void handlePreflight_usesCustomAllowedOrigin() {
         String customOrigin = "https://example.com";
-        MutableHttpRequest<?> request = mock(MutableHttpRequest.class);
-        when(request.getMethod()).thenReturn(HttpMethod.OPTIONS);
+        MutableHttpRequest<?> request = mockRequest(HttpMethod.OPTIONS);
 
         CorsFilter filter = new CorsFilter(customOrigin);
 


### PR DESCRIPTION
Implement a PrivacyController to handle the privacy policy endpoint, ensuring it bypasses API key authentication and rate limiting. Add unit and integration tests to validate the endpoint's functionality and response structure across different languages. Refactor existing tests for improved clarity.