### PR TITLE
Add city enable/disable feature with environment variable support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -387,6 +387,8 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL }}
           API_KEY_ELPRAT: ${{ secrets.API_KEY_ELPRAT }}
+          # City enable/disable — must be explicitly set to "true" to enable a city.
+          ENABLE_CITY_ELPRAT: ${{ vars.ENABLE_CITY_ELPRAT }}
           # Telegram Bot — per-city token and webhook secret
           TOKEN_TELEGRAM_ELPRAT: ${{ secrets.TOKEN_TELEGRAM_ELPRAT }}
           TELEGRAM_WEBHOOK_SECRET_ELPRAT: ${{ secrets.TELEGRAM_WEBHOOK_SECRET_ELPRAT }}

--- a/E2E-ComplAI/02-OK/folder.bru
+++ b/E2E-ComplAI/02-OK/folder.bru
@@ -1,6 +1,6 @@
 meta {
   name: OK
-  seq: 2
+  seq: 1
 }
 
 auth {

--- a/E2E-ComplAI/03-ERROR/folder.bru
+++ b/E2E-ComplAI/03-ERROR/folder.bru
@@ -1,6 +1,6 @@
 meta {
   name: ERROR
-  seq: 3
+  seq: 2
 }
 
 auth {

--- a/E2E-ComplAI/report/folder.bru
+++ b/E2E-ComplAI/report/folder.bru
@@ -1,4 +1,0 @@
-meta {
-  name: report
-  seq: 4
-}

--- a/cdk/lambda-stack.ts
+++ b/cdk/lambda-stack.ts
@@ -224,6 +224,9 @@ export class LambdaStack extends cdk.Stack {
         // GitHub Environment secret (API_KEY_<CITYID_UPPER>) for both development and production.
         API_KEY_ENABLED: 'true',
         API_KEY_ELPRAT: process.env.API_KEY_ELPRAT || '',
+        // City enable/disable — must be explicitly set to "true" for each city.
+        // Missing or "false" = city returns HTTP 503 CITY_DISABLED.
+        ENABLE_CITY_ELPRAT: 'true',
         // Telegram Bot configuration — per-city token and webhook secret.
         // To add a new city: add TOKEN_TELEGRAM_<CITYID_UPPER> and
         // TELEGRAM_WEBHOOK_SECRET_<CITYID_UPPER> here and set the corresponding
@@ -462,6 +465,8 @@ export class LambdaStack extends cdk.Stack {
         AWS_SES_REGION: process.env.AWS_SES_REGION || 'eu-west-1',
         // Per-city API keys for MultiCitySesService discovery (city must have BOTH API_KEY_* and AWS_SES_TO_EMAIL_*)
         API_KEY_ELPRAT: process.env.API_KEY_ELPRAT || '',
+        // City enable/disable — must be explicitly set to "true" for each city.
+        ENABLE_CITY_ELPRAT: 'true',
         // Telegram Bot — per-city token and webhook secret
         TOKEN_TELEGRAM_ELPRAT: process.env.TOKEN_TELEGRAM_ELPRAT || '',
         TELEGRAM_WEBHOOK_SECRET_ELPRAT: process.env.TELEGRAM_WEBHOOK_SECRET_ELPRAT || '',
@@ -627,6 +632,8 @@ export class LambdaStack extends cdk.Stack {
         COMPLAI_DEFAULT_CITY_ID: process.env.COMPLAI_DEFAULT_CITY_ID || 'elprat',
         // Per-city Telegram bot tokens for sending answers back
         TOKEN_TELEGRAM_ELPRAT: process.env.TOKEN_TELEGRAM_ELPRAT || '',
+        // City enable/disable — must be explicitly set to "true" for each city.
+        ENABLE_CITY_ELPRAT: 'true',
         // Allow LocalStack endpoint for local development
         ...(process.env.AWS_ENDPOINT_URL ? { AWS_ENDPOINT_URL: process.env.AWS_ENDPOINT_URL } : {}),
       },
@@ -735,6 +742,8 @@ export class LambdaStack extends cdk.Stack {
         FEEDBACK_BUCKET_NAME: feedbackBucket.bucketName,
         // Per-city API keys for MultiCitySesService discovery (city must have BOTH API_KEY_* and AWS_SES_TO_EMAIL_*)
         API_KEY_ELPRAT: process.env.API_KEY_ELPRAT || '',
+        // City enable/disable — must be explicitly set to "true" for each city.
+        ENABLE_CITY_ELPRAT: 'true',
         // Allow LocalStack endpoint for local development
         ...(process.env.AWS_ENDPOINT_URL ? { AWS_ENDPOINT_URL: process.env.AWS_ENDPOINT_URL } : {}),
       },

--- a/cdk/lambda-stack.ts
+++ b/cdk/lambda-stack.ts
@@ -224,9 +224,9 @@ export class LambdaStack extends cdk.Stack {
         // GitHub Environment secret (API_KEY_<CITYID_UPPER>) for both development and production.
         API_KEY_ENABLED: 'true',
         API_KEY_ELPRAT: process.env.API_KEY_ELPRAT || '',
-        // City enable/disable — must be explicitly set to "true" for each city.
-        // Missing or "false" = city returns HTTP 503 CITY_DISABLED.
-        ENABLE_CITY_ELPRAT: 'true',
+        // City enable/disable — read from GitHub Environment Variables.
+        // Must be explicitly set to "true" for each city. Defaults to disabled.
+        ENABLE_CITY_ELPRAT: process.env.ENABLE_CITY_ELPRAT || 'false',
         // Telegram Bot configuration — per-city token and webhook secret.
         // To add a new city: add TOKEN_TELEGRAM_<CITYID_UPPER> and
         // TELEGRAM_WEBHOOK_SECRET_<CITYID_UPPER> here and set the corresponding
@@ -465,8 +465,8 @@ export class LambdaStack extends cdk.Stack {
         AWS_SES_REGION: process.env.AWS_SES_REGION || 'eu-west-1',
         // Per-city API keys for MultiCitySesService discovery (city must have BOTH API_KEY_* and AWS_SES_TO_EMAIL_*)
         API_KEY_ELPRAT: process.env.API_KEY_ELPRAT || '',
-        // City enable/disable — must be explicitly set to "true" for each city.
-        ENABLE_CITY_ELPRAT: 'true',
+        // City enable/disable — read from GitHub Environment Variables.
+        ENABLE_CITY_ELPRAT: process.env.ENABLE_CITY_ELPRAT || 'false',
         // Telegram Bot — per-city token and webhook secret
         TOKEN_TELEGRAM_ELPRAT: process.env.TOKEN_TELEGRAM_ELPRAT || '',
         TELEGRAM_WEBHOOK_SECRET_ELPRAT: process.env.TELEGRAM_WEBHOOK_SECRET_ELPRAT || '',
@@ -632,8 +632,8 @@ export class LambdaStack extends cdk.Stack {
         COMPLAI_DEFAULT_CITY_ID: process.env.COMPLAI_DEFAULT_CITY_ID || 'elprat',
         // Per-city Telegram bot tokens for sending answers back
         TOKEN_TELEGRAM_ELPRAT: process.env.TOKEN_TELEGRAM_ELPRAT || '',
-        // City enable/disable — must be explicitly set to "true" for each city.
-        ENABLE_CITY_ELPRAT: 'true',
+        // City enable/disable — read from GitHub Environment Variables.
+        ENABLE_CITY_ELPRAT: process.env.ENABLE_CITY_ELPRAT || 'false',
         // Allow LocalStack endpoint for local development
         ...(process.env.AWS_ENDPOINT_URL ? { AWS_ENDPOINT_URL: process.env.AWS_ENDPOINT_URL } : {}),
       },
@@ -742,8 +742,8 @@ export class LambdaStack extends cdk.Stack {
         FEEDBACK_BUCKET_NAME: feedbackBucket.bucketName,
         // Per-city API keys for MultiCitySesService discovery (city must have BOTH API_KEY_* and AWS_SES_TO_EMAIL_*)
         API_KEY_ELPRAT: process.env.API_KEY_ELPRAT || '',
-        // City enable/disable — must be explicitly set to "true" for each city.
-        ENABLE_CITY_ELPRAT: 'true',
+        // City enable/disable — read from GitHub Environment Variables.
+        ENABLE_CITY_ELPRAT: process.env.ENABLE_CITY_ELPRAT || 'false',
         // Allow LocalStack endpoint for local development
         ...(process.env.AWS_ENDPOINT_URL ? { AWS_ENDPOINT_URL: process.env.AWS_ENDPOINT_URL } : {}),
       },

--- a/sam/env.json.example
+++ b/sam/env.json.example
@@ -25,6 +25,7 @@
     "OPENROUTER_URL": "https://openrouter.ai",
     "API_KEY_ENABLED": "true",
     "API_KEY_ELPRAT": "your-api-key-for-elprat",
+    "ENABLE_CITY_ELPRAT": "true",
     "TOKEN_TELEGRAM_ELPRAT": "your-telegram-bot-token-for-elprat",
     "TELEGRAM_WEBHOOK_SECRET_ELPRAT": "your-telegram-webhook-secret-for-elprat",
     "HTTP_CLIENT_CONNECT_TIMEOUT": "10s",

--- a/sam/template.yaml
+++ b/sam/template.yaml
@@ -48,6 +48,10 @@ Parameters:
     Type: String
     Default: ''
     Description: Webhook secret token for Telegram bot (city 'elprat').
+  EnableCityElprat:
+    Type: String
+    Default: 'true'
+    Description: Enable/disable city 'elprat' (true/false). City returns HTTP 503 when disabled.
 Conditions:
   IsProduction: !Equals [!Ref Environment, production]
 
@@ -348,6 +352,8 @@ Resources:
           OPENROUTER_MODEL: openrouter/free
           API_KEY_ENABLED: 'true'
           API_KEY_ELPRAT: !Ref ApiKeyElprat
+          # City enable/disable — must be explicitly set to "true" to enable a city.
+          ENABLE_CITY_ELPRAT: !Ref EnableCityElprat
           # Telegram Bot — per-city token and webhook secret
           TOKEN_TELEGRAM_ELPRAT: !Ref TokenTelegramElprat
           TELEGRAM_WEBHOOK_SECRET_ELPRAT: !Ref TelegramWebhookSecretElprat
@@ -413,6 +419,8 @@ Resources:
           API_KEY_ELPRAT: !Ref ApiKeyElprat
           TOKEN_TELEGRAM_ELPRAT: !Ref TokenTelegramElprat
           TELEGRAM_WEBHOOK_SECRET_ELPRAT: !Ref TelegramWebhookSecretElprat
+          # City enable/disable
+          ENABLE_CITY_ELPRAT: !Ref EnableCityElprat
       Events:
         SQSTrigger:
           Type: SQS
@@ -480,6 +488,8 @@ Resources:
           COMPLAI_DEFAULT_CITY_ID: elprat
           # Per-city Telegram bot tokens for sending answers back
           TOKEN_TELEGRAM_ELPRAT: !Ref TokenTelegramElprat
+          # City enable/disable
+          ENABLE_CITY_ELPRAT: !Ref EnableCityElprat
       Events:
         SQSTrigger:
           Type: SQS
@@ -554,6 +564,8 @@ Resources:
           ENVIRONMENT: !Ref Environment
           API_KEY_ELPRAT: !Ref ApiKeyElprat
           AWS_SES_TO_EMAIL_ELPRAT: !Ref SesToEmailElprat
+          # City enable/disable
+          ENABLE_CITY_ELPRAT: !Ref EnableCityElprat
           NEWS_BUCKET: !Ref NewsBucket
           NEWS_REGION: !Ref LambdaRegion
           CITYINFO_BUCKET: !Ref CityInfoBucket

--- a/src/main/java/cat/complai/controllers/telegram/TelegramController.java
+++ b/src/main/java/cat/complai/controllers/telegram/TelegramController.java
@@ -3,16 +3,22 @@ package cat.complai.controllers.telegram;
 import cat.complai.config.TelegramConfiguration;
 import cat.complai.controllers.telegram.dto.TelegramUpdate;
 import cat.complai.services.telegram.TelegramBotService;
+import cat.complai.utilities.auth.ApiKeyAuthFilter;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Status;
-import io.micronaut.http.HttpStatus;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
 
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 /**
@@ -32,13 +38,22 @@ public class TelegramController {
 
     private final TelegramConfiguration telegramConfig;
     private final TelegramBotService botService;
+    private final Predicate<String> cityEnabledChecker;
     private final Logger logger = Logger.getLogger(TelegramController.class.getName());
 
     @Inject
     public TelegramController(TelegramConfiguration telegramConfig,
                               TelegramBotService botService) {
+        this(telegramConfig, botService, ApiKeyAuthFilter::isCityEnabled);
+    }
+
+    // Visible for testing — accepts a custom city-enabled checker
+    public TelegramController(TelegramConfiguration telegramConfig,
+                              TelegramBotService botService,
+                              Predicate<String> cityEnabledChecker) {
         this.telegramConfig = telegramConfig;
         this.botService = botService;
+        this.cityEnabledChecker = cityEnabledChecker;
     }
 
     /**
@@ -62,6 +77,13 @@ public class TelegramController {
         if (cityId == null || cityId.isBlank()) {
             logger.warning("Telegram webhook called with missing cityId");
             return HttpResponse.badRequest();
+        }
+
+        // Check if city is enabled via ENABLE_CITY_<CITYID> environment variable.
+        // Defaults to disabled when the variable is absent.
+        if (!cityEnabledChecker.test(cityId)) {
+            logger.info(() -> "City disabled for Telegram — cityId=" + cityId);
+            return HttpResponse.status(HttpStatus.SERVICE_UNAVAILABLE);
         }
 
         // Verify webhook secret token if configured

--- a/src/main/java/cat/complai/dto/openrouter/OpenRouterErrorCode.java
+++ b/src/main/java/cat/complai/dto/openrouter/OpenRouterErrorCode.java
@@ -28,7 +28,10 @@ public enum OpenRouterErrorCode {
     // Emitted when the circuit breaker protecting OpenRouter calls is open.
     // The upstream provider is degraded and the request was rejected without
     // attempting the HTTP call.
-    CIRCUIT_OPEN(8);
+    CIRCUIT_OPEN(8),
+    // Emitted when a city is disabled via ENABLE_CITY_<CITYID> environment variable.
+    // The request is rejected with HTTP 503 Service Unavailable.
+    CITY_DISABLED(9);
 
     private final int code;
 

--- a/src/main/java/cat/complai/utilities/auth/ApiKeyAuthFilter.java
+++ b/src/main/java/cat/complai/utilities/auth/ApiKeyAuthFilter.java
@@ -6,13 +6,16 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.RequestFilter;
 import io.micronaut.http.annotation.ServerFilter;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 /**
@@ -45,9 +48,11 @@ public class ApiKeyAuthFilter {
     public static final String USER_ATTRIBUTE = "user";
 
     private final Map<String, String> apiKeyToCityId;
+    private final Set<String> disabledCities;
 
     public ApiKeyAuthFilter() {
         Map<String, String> map = new HashMap<>();
+        Set<String> disabled = new HashSet<>();
         for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
             if (entry.getKey().startsWith("API_KEY_")) {
                 String cityId = entry.getKey().substring("API_KEY_".length()).toLowerCase();
@@ -58,16 +63,32 @@ public class ApiKeyAuthFilter {
             throw new IllegalStateException(
                     "No API keys configured. Set at least one API_KEY_<CITYID> environment variable.");
         }
+        // Discover disabled cities: ENABLE_CITY_<CITYID> must be "true" to enable.
+        // Missing or any other value = disabled.
+        for (String cityId : new HashSet<>(map.values())) {
+            String enabled = System.getenv().getOrDefault("ENABLE_CITY_" + cityId.toUpperCase(), "false");
+            if (!"true".equalsIgnoreCase(enabled)) {
+                disabled.add(cityId);
+            }
+        }
         this.apiKeyToCityId = Map.copyOf(map);
-        logger.info(() -> "ApiKeyAuthFilter initialized with " + apiKeyToCityId.size() + " API key(s).");
+        this.disabledCities = Set.copyOf(disabled);
+        logger.info(() -> "ApiKeyAuthFilter initialized with " + apiKeyToCityId.size() + " API key(s), "
+                + disabledCities.size() + " disabled.");
     }
 
     // Visible for unit tests — accepts a pre-built map instead of scanning System.getenv()
     public ApiKeyAuthFilter(Map<String, String> apiKeyToCityId) {
+        this(apiKeyToCityId, Set.of());
+    }
+
+    // Visible for unit tests — accepts both API key map and disabled cities set
+    public ApiKeyAuthFilter(Map<String, String> apiKeyToCityId, Set<String> disabledCities) {
         if (apiKeyToCityId.isEmpty()) {
             throw new IllegalStateException("No API keys configured.");
         }
         this.apiKeyToCityId = Map.copyOf(apiKeyToCityId);
+        this.disabledCities = Set.copyOf(disabledCities);
         logger.info(
                 () -> "ApiKeyAuthFilter initialized with " + this.apiKeyToCityId.size() + " API key(s) (test).");
     }
@@ -98,6 +119,12 @@ public class ApiKeyAuthFilter {
             return unauthorizedResponse("Invalid API key");
         }
 
+        if (disabledCities.contains(cityId)) {
+            logger.info(() -> "City disabled — cityId=" + cityId + " httpStatus=503 method=" + request.getMethod()
+                    + " path=" + request.getPath());
+            return cityDisabledResponse(cityId);
+        }
+
         request.setAttribute(CITY_ATTRIBUTE, cityId);
         request.setAttribute(USER_ATTRIBUTE, "api-key-client");
 
@@ -124,5 +151,23 @@ public class ApiKeyAuthFilter {
                 "message", reason == null ? "Unauthorized" : reason,
                 "errorCode", OpenRouterErrorCode.UNAUTHORIZED.getCode());
         return HttpResponse.unauthorized().body(body);
+    }
+
+    private MutableHttpResponse<?> cityDisabledResponse(String cityId) {
+        Map<String, Object> body = Map.of(
+                "success", false,
+                "message", "City '" + cityId + "' is currently unavailable",
+                "errorCode", OpenRouterErrorCode.CITY_DISABLED.getCode());
+        return HttpResponse.status(HttpStatus.SERVICE_UNAVAILABLE).body(body);
+    }
+
+    /**
+     * Returns true if the given city is enabled via the
+     * {@code ENABLE_CITY_<CITYID>} environment variable.
+     * Defaults to disabled (false) when the variable is absent.
+     */
+    public static boolean isCityEnabled(String cityId) {
+        String enabled = System.getenv().getOrDefault("ENABLE_CITY_" + cityId.toUpperCase(), "false");
+        return "true".equalsIgnoreCase(enabled);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -115,6 +115,14 @@ complai.rate-limit.requests-per-minute=${RATE_LIMIT_REQUESTS_PER_MINUTE:20}
 # Default city for RAG index pre-warming at startup. Override via env var for multi-city deployments.
 complai.default-city-id=${COMPLAI_DEFAULT_CITY_ID:elprat}
 
+# City enable/disable — per-city toggle via ENABLE_CITY_<CITYID> environment variable.
+# MUST be explicitly set to "true" for a city to be available. If the variable is missing
+# or set to any other value, the city is disabled and returns HTTP 503 CITY_DISABLED (errorCode 9).
+# Affects all endpoints: chat (ask), redact, feedback, and Telegram webhooks.
+# To enable a city: set ENABLE_CITY_<CITYID>=true (e.g. ENABLE_CITY_ELPRAT=true)
+# To disable a city: remove the variable or set it to "false"
+# To add a new city: set both API_KEY_<CITYID> AND ENABLE_CITY_<CITYID>=true
+
 # RAG retrieval engine rollout configuration.
 # Java retrieval is now the only supported engine.
 rag.retrieval.engine=${RAG_RETRIEVAL_ENGINE:java}

--- a/src/test/java/cat/complai/controllers/telegram/TelegramControllerTest.java
+++ b/src/test/java/cat/complai/controllers/telegram/TelegramControllerTest.java
@@ -86,6 +86,9 @@ public class TelegramControllerTest {
         return req;
     }
 
+    /** Default checker that allows all cities — used by most tests. */
+    private static final java.util.function.Predicate<String> ALLOW_ALL = cityId -> true;
+
     // -------------------------------------------------------------------------
     // Tests
     // -------------------------------------------------------------------------
@@ -94,7 +97,7 @@ public class TelegramControllerTest {
     void webhook_validUpdate_returns200() {
         var config = new FakeTelegramConfig();
         var botService = new FakeBotService();
-        var controller = new TelegramController(config, botService);
+        var controller = new TelegramController(config, botService, ALLOW_ALL);
 
         var chat = new TelegramChat(12345L, "private", "Test");
         var user = new TelegramUser(67890L, false, "TestUser", "en");
@@ -114,7 +117,7 @@ public class TelegramControllerTest {
     void webhook_missingCityId_returns400() {
         var config = new FakeTelegramConfig();
         var botService = new FakeBotService();
-        var controller = new TelegramController(config, botService);
+        var controller = new TelegramController(config, botService, ALLOW_ALL);
 
         var update = new TelegramUpdate(42L, null, null);
 
@@ -130,7 +133,7 @@ public class TelegramControllerTest {
     void webhook_wrongSecret_returns401() {
         var config = new FakeTelegramConfig();
         var botService = new FakeBotService();
-        var controller = new TelegramController(config, botService);
+        var controller = new TelegramController(config, botService, ALLOW_ALL);
 
         var update = new TelegramUpdate(42L, null, null);
 
@@ -146,7 +149,7 @@ public class TelegramControllerTest {
     void webhook_validSecret_passesVerification() {
         var config = new FakeTelegramConfig();
         var botService = new FakeBotService();
-        var controller = new TelegramController(config, botService);
+        var controller = new TelegramController(config, botService, ALLOW_ALL);
 
         var chat = new TelegramChat(12345L, "private", "Test");
         var user = new TelegramUser(67890L, false, "TestUser", "en");
@@ -160,5 +163,44 @@ public class TelegramControllerTest {
         assertEquals(1, botService.receivedUpdates.size());
         assertSame(update, botService.receivedUpdates.get(0));
         assertEquals("elprat", botService.receivedCities.get(0));
+    }
+
+    @Test
+    void webhook_disabledCity_returns503() {
+        var config = new FakeTelegramConfig();
+        var botService = new FakeBotService();
+        // Checker that disables elprat
+        var controller = new TelegramController(config, botService, cityId -> false);
+
+        var chat = new TelegramChat(12345L, "private", "Test");
+        var user = new TelegramUser(67890L, false, "TestUser", "en");
+        var message = new TelegramMessage(1, user, chat, 1000000L, "Hello bot");
+        var update = new TelegramUpdate(42L, message, null);
+
+        HttpResponse<?> response = controller.webhook(update, "elprat",
+                requestWithSecret("test-secret"));
+
+        assertEquals(503, response.getStatus().getCode());
+        assertTrue(botService.receivedUpdates.isEmpty(),
+                "Bot service must not be called when city is disabled");
+    }
+
+    @Test
+    void webhook_enabledCity_returns200() {
+        var config = new FakeTelegramConfig();
+        var botService = new FakeBotService();
+        // Checker that enables all cities
+        var controller = new TelegramController(config, botService, cityId -> true);
+
+        var chat = new TelegramChat(12345L, "private", "Test");
+        var user = new TelegramUser(67890L, false, "TestUser", "en");
+        var message = new TelegramMessage(1, user, chat, 1000000L, "Hello bot");
+        var update = new TelegramUpdate(42L, message, null);
+
+        HttpResponse<?> response = controller.webhook(update, "elprat",
+                requestWithSecret("test-secret"));
+
+        assertEquals(200, response.getStatus().getCode());
+        assertEquals(1, botService.receivedUpdates.size());
     }
 }

--- a/src/test/java/cat/complai/dto/DTOTest.java
+++ b/src/test/java/cat/complai/dto/DTOTest.java
@@ -548,7 +548,7 @@ class DTOTest {
         @Test
         @DisplayName("Should have expected enum constants")
         void shouldHaveExpectedConstants() {
-            assertEquals(9, OpenRouterErrorCode.values().length);
+            assertEquals(10, OpenRouterErrorCode.values().length);
         }
 
         @Test

--- a/src/test/java/cat/complai/utilities/auth/ApiKeyAuthFilterTest.java
+++ b/src/test/java/cat/complai/utilities/auth/ApiKeyAuthFilterTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -105,5 +106,109 @@ class ApiKeyAuthFilterTest {
     @Test
     void constructorWithEmptyMap_throwsIllegalState() {
         assertThrows(IllegalStateException.class, () -> new ApiKeyAuthFilter(Map.of()));
+    }
+
+    // --- City enable/disable ---
+
+    @Test
+    void disabledCity_returns503() {
+        ApiKeyAuthFilter disabledFilter = new ApiKeyAuthFilter(
+                Map.of("test-key-elprat", "elprat"), Set.of("elprat"));
+        MutableHttpRequest<?> request = HttpRequest.POST("/complai/ask", "{}")
+                .header("X-Api-Key", "test-key-elprat");
+        MutableHttpResponse<?> response = disabledFilter.filter(request);
+        assertNotNull(response, "Disabled city must return a response (not null)");
+        assertEquals(503, response.getStatus().getCode());
+    }
+
+    @Test
+    void disabledCity_returnsCityDisabledErrorCode() {
+        ApiKeyAuthFilter disabledFilter = new ApiKeyAuthFilter(
+                Map.of("test-key-elprat", "elprat"), Set.of("elprat"));
+        MutableHttpRequest<?> request = HttpRequest.POST("/complai/ask", "{}")
+                .header("X-Api-Key", "test-key-elprat");
+        MutableHttpResponse<?> response = disabledFilter.filter(request);
+        assertNotNull(response);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.body();
+        assertEquals(9, body.get("errorCode"), "Must return CITY_DISABLED error code (9)");
+        assertFalse((Boolean) body.get("success"));
+    }
+
+    @Test
+    void disabledCity_doesNotSetAttributes() {
+        ApiKeyAuthFilter disabledFilter = new ApiKeyAuthFilter(
+                Map.of("test-key-elprat", "elprat"), Set.of("elprat"));
+        MutableHttpRequest<?> request = HttpRequest.POST("/complai/ask", "{}")
+                .header("X-Api-Key", "test-key-elprat");
+        disabledFilter.filter(request);
+        assertFalse(request.getAttribute("city", String.class).isPresent(),
+                "Disabled city must not set city attribute");
+    }
+
+    @Test
+    void enabledCity_returnsNull() {
+        ApiKeyAuthFilter enabledFilter = new ApiKeyAuthFilter(
+                Map.of("test-key-elprat", "elprat"), Set.of());
+        MutableHttpRequest<?> request = HttpRequest.POST("/complai/ask", "{}")
+                .header("X-Api-Key", "test-key-elprat");
+        assertNull(enabledFilter.filter(request), "Enabled city must pass through (return null)");
+    }
+
+    @Test
+    void enabledCity_setsAttributes() {
+        ApiKeyAuthFilter enabledFilter = new ApiKeyAuthFilter(
+                Map.of("test-key-elprat", "elprat"), Set.of());
+        MutableHttpRequest<?> request = HttpRequest.POST("/complai/ask", "{}")
+                .header("X-Api-Key", "test-key-elprat");
+        enabledFilter.filter(request);
+        assertEquals("elprat", request.getAttribute("city", String.class).orElse(""));
+        assertEquals("api-key-client", request.getAttribute("user", String.class).orElse(""));
+    }
+
+    @Test
+    void getHealth_disabledCity_returnsNull() {
+        ApiKeyAuthFilter disabledFilter = new ApiKeyAuthFilter(
+                Map.of("test-key-elprat", "elprat"), Set.of("elprat"));
+        MutableHttpRequest<?> request = HttpRequest.GET("/health");
+        assertNull(disabledFilter.filter(request),
+                "GET /health must pass through even for disabled cities");
+    }
+
+    @Test
+    void getPrivacy_disabledCity_returnsNull() {
+        ApiKeyAuthFilter disabledFilter = new ApiKeyAuthFilter(
+                Map.of("test-key-elprat", "elprat"), Set.of("elprat"));
+        MutableHttpRequest<?> request = HttpRequest.GET("/privacy");
+        assertNull(disabledFilter.filter(request),
+                "GET /privacy must pass through even for disabled cities");
+    }
+
+    @Test
+    void telegramWebhook_disabledCity_returnsNull() {
+        ApiKeyAuthFilter disabledFilter = new ApiKeyAuthFilter(
+                Map.of("test-key-elprat", "elprat"), Set.of("elprat"));
+        MutableHttpRequest<?> request = HttpRequest.POST("/telegram/webhook/elprat", "{}");
+        assertNull(disabledFilter.filter(request),
+                "Telegram webhooks must pass through (excluded from auth filter)");
+    }
+
+    @Test
+    void multiCityFilter_oneDisabledOneEnabled() {
+        ApiKeyAuthFilter mixedFilter = new ApiKeyAuthFilter(
+                Map.of("key-a", "citya", "key-b", "cityb"),
+                Set.of("citya"));
+
+        // Disabled city returns 503
+        MutableHttpRequest<?> requestA = HttpRequest.POST("/complai/ask", "{}")
+                .header("X-Api-Key", "key-a");
+        MutableHttpResponse<?> responseA = mixedFilter.filter(requestA);
+        assertNotNull(responseA);
+        assertEquals(503, responseA.getStatus().getCode());
+
+        // Enabled city passes through
+        MutableHttpRequest<?> requestB = HttpRequest.POST("/complai/ask", "{}")
+                .header("X-Api-Key", "key-b");
+        assertNull(mixedFilter.filter(requestB), "Enabled city must pass through");
     }
 }

--- a/src/test/java/cat/complai/utilities/auth/TestApiKeyFilter.java
+++ b/src/test/java/cat/complai/utilities/auth/TestApiKeyFilter.java
@@ -6,6 +6,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.RequestFilter;
@@ -13,6 +14,7 @@ import io.micronaut.http.annotation.ServerFilter;
 import jakarta.inject.Singleton;
 
 import java.util.Map;
+import java.util.Set;
 
 @Singleton
 @ServerFilter("/**")
@@ -24,6 +26,26 @@ public class TestApiKeyFilter {
             "test-integration-key-testcity", "testcity",
             "test-api-key-feedback", "elprat",
             "test-integration-key-elprat-htmlsources", "testcity");
+
+    /** Cities that should return 503 CITY_DISABLED in tests. */
+    private final Set<String> disabledCities;
+
+    public TestApiKeyFilter() {
+        // Discover disabled cities from ENABLE_CITY_<CITYID> env vars.
+        // In tests, cities are enabled by default unless ENABLE_CITY_X=false is set.
+        this.disabledCities = apiKeyToCityId.values().stream()
+                .distinct()
+                .filter(cityId -> {
+                    String enabled = System.getenv().getOrDefault("ENABLE_CITY_" + cityId.toUpperCase(), "true");
+                    return "false".equalsIgnoreCase(enabled);
+                })
+                .collect(java.util.stream.Collectors.toSet());
+    }
+
+    // Visible for tests — accepts a custom disabled cities set
+    public TestApiKeyFilter(Set<String> disabledCities) {
+        this.disabledCities = Set.copyOf(disabledCities);
+    }
 
     @RequestFilter
     @Nullable
@@ -44,6 +66,10 @@ public class TestApiKeyFilter {
         String cityId = apiKeyToCityId.get(apiKey);
         if (cityId == null) {
             return unauthorizedResponse("Invalid API key");
+        }
+
+        if (disabledCities.contains(cityId)) {
+            return cityDisabledResponse(cityId);
         }
 
         request.setAttribute(ApiKeyAuthFilter.CITY_ATTRIBUTE, cityId);
@@ -70,5 +96,13 @@ public class TestApiKeyFilter {
                 "message", reason == null ? "Unauthorized" : reason,
                 "errorCode", OpenRouterErrorCode.UNAUTHORIZED.getCode());
         return HttpResponse.unauthorized().body(body);
+    }
+
+    private MutableHttpResponse<?> cityDisabledResponse(String cityId) {
+        Map<String, Object> body = Map.of(
+                "success", false,
+                "message", "City '" + cityId + "' is currently unavailable",
+                "errorCode", OpenRouterErrorCode.CITY_DISABLED.getCode());
+        return HttpResponse.status(HttpStatus.SERVICE_UNAVAILABLE).body(body);
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -27,3 +27,7 @@ rag.ambiguity.score-ratio-threshold=0.85
 aws.ses.from-email=test-sender@example.local
 aws.ses.region=eu-west-1
 aws.ses.recipient-email=test-recipient@example.local
+
+# City enable/disable testing — testcity is explicitly disabled for testing
+# the CITY_DISABLED error path. elprat is enabled by default (not set = enabled in test filter).
+ENABLE_CITY_TESTCITY=false


### PR DESCRIPTION
Introduce a feature that allows enabling or disabling cities via environment variables. Update configuration and tests to support this functionality, ensuring cities return appropriate responses based on their enabled status.